### PR TITLE
Make Articulation CustomStringConvertible

### DIFF
--- a/Articulations/Articulation.swift
+++ b/Articulations/Articulation.swift
@@ -7,23 +7,23 @@
 //
 
 public struct Articulation: OptionSet {
-    
+
     // MARK: - Instance Properties
-    
+
     /// Raw value.
     public var rawValue: Int
-    
+
     // MARK: - Initializers
-    
+
     /// Create an `Articulation` with a given `rawValue`.
     public init(rawValue: Int) {
         self.rawValue = rawValue
     }
-    
+
     public static let staccato = Articulation(rawValue: 1 << 0)
     public static let staccatissimo = Articulation(rawValue: 1 << 1)
     public static let tenuto = Articulation(rawValue: 1 << 2)
     public static let accent = Articulation(rawValue: 1 << 3)
-    
+
     // TODO: More
 }

--- a/Articulations/Articulation.swift
+++ b/Articulations/Articulation.swift
@@ -27,3 +27,24 @@ public struct Articulation: OptionSet {
 
     // TODO: More
 }
+
+extension Articulation: CustomStringConvertible {
+
+    // MARK: - CustomStringConvertible
+
+    /// Description
+    public var description: String {
+        switch rawValue {
+        case Articulation.staccato.rawValue:
+            return "staccato"
+        case Articulation.staccatissimo.rawValue:
+            return "staccatissimo"
+        case Articulation.tenuto.rawValue:
+            return "tenuto"
+        case Articulation.accent.rawValue:
+            return "accent"
+        default:
+            return "\(rawValue)"
+        }
+    }
+}


### PR DESCRIPTION
Fix for #1.

Based on `extension IntervalRelation: CustomStringConvertible`.

I think using `case Articulation.staccato.rawValue` is slightly better because the magic/meaningless number is then only in one place. I would guess that the calls are optimized out?